### PR TITLE
fix: correct review relations

### DIFF
--- a/app/api/admin/reviews/route.ts
+++ b/app/api/admin/reviews/route.ts
@@ -36,10 +36,11 @@ export async function GET(request: NextRequest) {
               email: true,
             }
           },
-          product: {
+          company: {
             select: {
               id: true,
               name: true,
+              verified: true,
             }
           }
         },


### PR DESCRIPTION
## Summary
- fix admin review update to fetch company instead of product and handle missing user
- update admin reviews list to include company details

## Testing
- `npx jest __tests__/security/penetration-testing.test.ts` (fails: CacheService module error)
- `npm run build` (fails: users route type error)


------
https://chatgpt.com/codex/tasks/task_e_688c54829dc48326bca4fa214bc16764